### PR TITLE
Tome crash fix and fix acidic_compound

### DIFF
--- a/elepower_dynamics/craftitems.lua
+++ b/elepower_dynamics/craftitems.lua
@@ -193,7 +193,7 @@ minetest.register_craftitem("elepower_dynamics:acidic_compound", {
 		local pos  = pointed_thing.under
 		local node = minetest.get_node(pos)
 		
-		if node.name ~= epi.water_source then
+		if node.name ~= epr.water_source then
 			return itemstack
 		end
 

--- a/elepower_tome/i_functions.lua
+++ b/elepower_tome/i_functions.lua
@@ -238,7 +238,7 @@ function eletome.gen_craft_grid(recipe,y_off,no_items)
 			-- handle when recipe includes groups
 			if string.find(recipe.items[x_cnt],"group") then
 				local grp_name = string.gsub(recipe.items[x_cnt],"group:","")
-				local node_name
+				local node_name = "UNKNOWN"
 				for name,def in pairs(minetest.registered_nodes) do 
 					if def.groups[grp_name] and not def.groups["wall"] then
 						node_name = name


### PR DESCRIPTION
Two commits, two fixes:
1. When node_name is nil, a lua error when some pages are viewed in the tome. Making it non-nil makes it not crash.
2. acidic_compound was checking `epi.` instead of `epr.` for water_source which was nil. No crash, but acidic_compund cannot be created as a result.